### PR TITLE
Use workflow-engine actions and upgrade to v0.0.1-rc.9

### DIFF
--- a/.github/workflows/delivery.yaml
+++ b/.github/workflows/delivery.yaml
@@ -1,0 +1,62 @@
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        type: string
+        description: Name to use when tagging the container image (e.g. `my-app:latest`)
+      build_dir:
+        type: string
+        description: The directory of the project being built
+
+env:
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
+  OUTPUT_DIR: ./.artifacts
+
+jobs:
+  get_settings:
+    runs-on: ubuntu-latest
+    outputs:
+      WORKFLOW_ENGINE_VERSION: ${{ steps.output.outputs.WORKFLOW_ENGINE_VERSION }}
+    steps:
+      - id: output
+        run: |
+          echo "WORKFLOW_ENGINE_VERSION=${{ env.WORKFLOW_ENGINE_VERSION }}" | tee -a $GITHUB_OUTPUT
+
+  build_scan_publish_image:
+    runs-on: ubuntu-latest
+    needs: [get_settings]
+    container:
+      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.get_settings.outputs.WORKFLOW_ENGINE_VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Image Build
+        uses: CMS-Enterprise/batcave-workflow-engine/.github/actions/image-build@actions-v0.0.1-rc.9
+        with:
+          build_dir: "${{ inputs.build_dir }}"
+          dockerfile: "${{ inputs.build_dir }}/Dockerfile"
+          tag: ${{ inputs.image_tag }}
+
+      - name: Image Scan
+        uses: CMS-Enterprise/batcave-workflow-engine/.github/actions/image-scan@actions-v0.0.1-rc.9
+        with:
+          tag: ${{ inputs.image_tag }}
+          artifact_dir: ${{ env.OUTPUT_DIR }}
+
+      - name: Image Publish
+        shell: sh
+        run: |-
+          export TEMP_IMAGE_TAG="ttl.sh/$(cat /proc/sys/kernel/random/uuid):30m"
+          export BUNDLE_TAG="ttl.sh/$(cat /proc/sys/kernel/random/uuid):30m"
+          # TODO: request the creation of a package at the Organization level or switch to artifactory
+          docker tag ${{ inputs.image_tag }} $TEMP_IMAGE_TAG
+          workflow-engine run image-publish --tag $TEMP_IMAGE_TAG --bundle-tag $BUNDLE_TAG --artifact-dir ${{ env.OUTPUT_DIR }}
+
+      - name: Archive image scan outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-scan-results
+          path: |
+            ${{ env.OUTPUT_DIR }}/*.txt
+            ${{ env.OUTPUT_DIR }}/*.json
+          if-no-files-found: error

--- a/.github/workflows/go-server.yml
+++ b/.github/workflows/go-server.yml
@@ -3,9 +3,7 @@ run-name: "Build Knight-Light Go Server: ${{ github.event.head_commit.message }}
 on: [push, workflow_dispatch]
 
 env:
-  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.4
-  OUTPUT_DIR: ./artifacts
-  WORKING_DIR: $GITHUB_WORKSPACE/go-server
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
 
 jobs:
   set-version:
@@ -58,27 +56,8 @@ jobs:
           workflow-engine run code-scan --semgrep-experimental
 
   delivery:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    container:
-      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.set-version.outputs.WORKFLOW_ENGINE_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Image Build
-        shell: sh
-        run: |-
-          cd go-server
-          workflow-engine run image-build --tag go-server-image
-      - name: Image Scan
-        shell: sh
-        run: |-
-          cd go-server
-          mkdir -p .artifacts
-          workflow-engine run image-scan --artifact-directory .artifacts --scan-image-target go-server-image
-          ls -la .artifacts
-      - name: Image Publish
-        shell: sh
-        run: |-
-          cd go-server
-          ls -la .artifacts
-          workflow-engine run image-publish --bundle-directory .artifacts
+    uses: ./.github/workflows/delivery.yaml
+    with:
+      image_tag: ghcr.io/cms-enterprise/batcave/knight-light-go-server
+      build_dir: ./go-server
+

--- a/.github/workflows/java-server.yml
+++ b/.github/workflows/java-server.yml
@@ -3,9 +3,7 @@ run-name: "Build Knight-Light Java Server: ${{ github.event.head_commit.message 
 on: [push, workflow_dispatch]
 
 env:
-  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.4
-  OUTPUT_DIR: ./artifacts
-  WORKING_DIR: $GITHUB_WORKSPACE/java-server
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
 
 jobs:
   build:
@@ -46,33 +44,7 @@ jobs:
         run: |
           cd java-server
           mvn clean test
-  # delivery:
-  #   needs: [build, test]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     # TODO combine all delivery jobs into a single action
-  #     - name: Build container image
-  #       uses: CMS-Enterprise/batcave-workflow-engine/.github/actions/image-build@main
-  #       with:
-  #         path: ./java-server/
-  #         # TODO: the dockerfile path should be relative to the context path
-  #         dockerfile: ./java-server/Dockerfile
-  #         # TODO: add support for mixed case to workflow-engine (i.e. we should force container image tags to lowercase)
-  #         image_tag: cms-enterprise/batcave/knight-light-java-server:testing
-  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Scan container image
-  #       uses: CMS-Enterprise/batcave-workflow-engine/.github/actions/image-scan@main
-  #       with:
-  #         image_tag: cms-enterprise/batcave/knight-light-java-server:testing
-  #         output_dir: ./artifacts
-  #         repo_token: ${{ secrets.GITHUB_TOKEN }}
-  #     - name: Archive image scan outputs
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: image-scan-results
-  #         path: ./artifacts/*.json
-  #         if-no-files-found: error
+
   sast:
     runs-on: ubuntu-latest
     needs: [set-version]
@@ -88,27 +60,7 @@ jobs:
           workflow-engine run code-scan --semgrep-experimental
 
   delivery:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    container:
-      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.set-version.outputs.WORKFLOW_ENGINE_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Image Build
-        shell: sh
-        run: |-
-          cd java-server
-          workflow-engine run image-build --tag java-server-image
-      - name: Image Scan
-        shell: sh
-        run: |-
-          cd java-server
-          mkdir -p .artifacts
-          workflow-engine run image-scan --artifact-directory .artifacts --scan-image-target java-server-image
-          ls -la .artifacts
-      - name: Image Publish
-        shell: sh
-        run: |-
-          cd java-server
-          ls -la .artifacts
-          workflow-engine run image-publish --bundle-directory .artifacts
+    uses: ./.github/workflows/delivery.yaml
+    with:
+      image_tag: ghcr.io/cms-enterprise/batcave/knight-light-java-server
+      build_dir: ./java-server

--- a/.github/workflows/node-server.yml
+++ b/.github/workflows/node-server.yml
@@ -3,9 +3,7 @@ run-name: "Build Knight-Light NodeJS Server: ${{ github.event.head_commit.messag
 on: [push, workflow_dispatch]
 
 env:
-  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.4
-  OUTPUT_DIR: ./artifacts
-  WORKING_DIR: $GITHUB_WORKSPACE/nodeJs-server
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
 
 jobs:
   set-version:
@@ -58,27 +56,7 @@ jobs:
           workflow-engine run code-scan --semgrep-experimental
 
   delivery:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    container:
-      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.set-version.outputs.WORKFLOW_ENGINE_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Image Build
-        shell: sh
-        run: |-
-          cd nodeJs-server
-          workflow-engine run image-build --tag node-server-image
-      - name: Image Scan
-        shell: sh
-        run: |-
-          cd nodeJs-server
-          mkdir -p .artifacts
-          workflow-engine run image-scan --artifact-directory .artifacts --scan-image-target node-server-image
-          ls -la .artifacts
-      - name: Image Publish
-        shell: sh
-        run: |- 
-          cd nodeJs-server
-          ls -la .artifacts
-          workflow-engine run image-publish --bundle-directory .artifacts
+    uses: ./.github/workflows/delivery.yaml
+    with:
+      image_tag: ghcr.io/cms-enterprise/batcave/knight-light-node-server
+      build_dir: ./nodeJs-server

--- a/.github/workflows/python-server.yml
+++ b/.github/workflows/python-server.yml
@@ -3,9 +3,7 @@ run-name: "Build Knight-Light Python Server: ${{ github.event.head_commit.messag
 on: [push, workflow_dispatch]
 
 env:
-  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.4
-  OUTPUT_DIR: ./artifacts
-  WORKING_DIR: $GITHUB_WORKSPACE/python-server
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
 
 jobs:
   test:
@@ -50,28 +48,9 @@ jobs:
           cd python-server
           mkdir -p .artifacts
           workflow-engine run code-scan --semgrep-experimental
+
   delivery:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    container:
-      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.set-version.outputs.WORKFLOW_ENGINE_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Image Build
-        shell: sh
-        run: |-
-          cd python-server
-          workflow-engine run image-build --tag python-server-image
-      - name: Image Scan
-        shell: sh
-        run: |-
-          cd python-server
-          mkdir -p .artifacts
-          workflow-engine run image-scan --artifact-directory .artifacts --scan-image-target python-server-image
-          ls -la .artifacts
-      - name: Image Publish
-        shell: sh
-        run: |- 
-          cd python-server
-          ls -la .artifacts
-          workflow-engine run image-publish --bundle-directory .artifacts
+    uses: ./.github/workflows/delivery.yaml
+    with:
+      image_tag: ghcr.io/cms-enterprise/batcave/knight-light-python-server
+      build_dir: ./python-server

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -3,9 +3,7 @@ run-name: "Build Knight-Light UI: ${{ github.event.head_commit.message }}"
 on: [push, workflow_dispatch]
 
 env:
-  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.4
-  OUTPUT_DIR: ./artifacts
-  WORKING_DIR: $GITHUB_WORKSPACE/ui
+  WORKFLOW_ENGINE_VERSION: v0.0.1-rc.9
 
 jobs:
   set-version:
@@ -43,28 +41,9 @@ jobs:
           cd ui
           npm ci
           npm run test
+
   delivery:
-    runs-on: ubuntu-latest
-    needs: [set-version]
-    container:
-      image: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ needs.set-version.outputs.WORKFLOW_ENGINE_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Image Build
-        shell: sh
-        run: |-
-          cd ui
-          workflow-engine run image-build --tag ui-image
-      - name: Image Scan
-        shell: sh
-        run: |-
-          cd ui
-          mkdir -p .artifacts
-          workflow-engine run image-scan --artifact-directory .artifacts --scan-image-target ui-image
-          ls -la .artifacts
-      - name: Image Publish
-        shell: sh
-        run: |-
-          cd ui
-          ls -la .artifacts
-          workflow-engine run image-publish --bundle-directory .artifacts
+    uses: ./.github/workflows/delivery.yaml
+    with:
+      image_tag: ghcr.io/cms-enterprise/batcave/knight-light-ui
+      build_dir: ./ui


### PR DESCRIPTION
 * batcave-workflow-engine defines standard image-build and image-scan actions. Using them simplifies things
 * The delivery job for all the knight-light projects is nearly identical, so it can be encapsulated in a reusable workflow.